### PR TITLE
Add 3D/2D canvas demo

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,3 @@
 # gpt
+
+This repository contains a simple example of a 3D and 2D canvas for creating gamified e-learning content. Open `elearning-canvas/index.html` in a modern web browser to try the demo.

--- a/elearning-canvas/index.html
+++ b/elearning-canvas/index.html
@@ -1,0 +1,49 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>Interactive eLearning Canvas</title>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/p5.js/1.4.2/p5.min.js"></script>
+  <script src="https://aframe.io/releases/1.3.0/aframe.min.js"></script>
+  <style>
+    body { font-family: sans-serif; margin: 0; }
+    #canvas3d { width: 100%; height: 50vh; }
+    #canvas2d { width: 100%; height: 50vh; }
+    #content { width: 100%; display: flex; flex-direction: column; height: 100vh; }
+  </style>
+</head>
+<body>
+  <h1>Gamified eLearning Canvas</h1>
+
+  <div id="content">
+    <div id="canvas3d">
+      <a-scene embedded>
+        <a-box position="0 1 -3" rotation="0 45 0" color="#4CC3D9"></a-box>
+        <a-sphere position="1.5 1 -4" radius="1" color="#EF2D5E"></a-sphere>
+        <a-plane position="0 0 -4" rotation="-90 0 0" width="4" height="4" color="#7BC8A4"></a-plane>
+        <a-sky color="#ECECEC"></a-sky>
+      </a-scene>
+    </div>
+
+    <div id="canvas2d"></div>
+  </div>
+
+  <script>
+    let x = 0;
+    function setup() {
+      const c = createCanvas(windowWidth, windowHeight/2);
+      c.parent('canvas2d');
+    }
+    function draw() {
+      background(200);
+      fill('orange');
+      ellipse(x, height/2, 50, 50);
+      x += 1;
+      if (x > width) x = 0;
+    }
+    function windowResized() {
+      resizeCanvas(windowWidth, windowHeight/2);
+    }
+  </script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add `elearning-canvas/index.html` with a simple 2D+3D canvas example
- update README with instructions for the new demo

## Testing
- `npm test` *(fails: cannot find package.json)*