### PR TITLE
Update grid layout and canvas sizes

### DIFF
--- a/elearning-canvas/index.html
+++ b/elearning-canvas/index.html
@@ -7,9 +7,30 @@
   <script src="https://aframe.io/releases/1.3.0/aframe.min.js"></script>
   <style>
     body { font-family: sans-serif; margin: 0; }
-    #canvas3d { width: 100%; height: 50vh; }
-    #canvas2d { width: 100%; height: 50vh; }
-    #content { width: 100%; display: flex; flex-direction: column; height: 100vh; }
+    /* grid layout */
+    #content {
+      display: grid;
+      grid-template-columns: 500px 300px 300px;
+      grid-template-rows: 500px 300px 300px;
+      width: 1100px;
+      height: 1100px;
+      margin: 0 auto;
+    }
+    /* 3D canvas positioned at row2 / column3 */
+    #canvas3d {
+      grid-row: 2;
+      grid-column: 3;
+      width: 300px;
+      height: 300px;
+      margin: auto;
+    }
+    /* big photo canvas */
+    #canvas2d {
+      grid-row: 2;
+      grid-column: 1 / span 2;
+      width: 800px;
+      height: 800px;
+    }
   </style>
 </head>
 <body>
@@ -22,6 +43,9 @@
       <a-scene embedded>
         <a-box position="0 1 -3" rotation="0 45 0" color="#4CC3D9"></a-box>
         <a-sphere position="1.5 1 -4" radius="1" color="#EF2D5E"></a-sphere>
+        <a-cylinder position="-1 0.5 -2" radius="0.3" height="1" color="#FFC65D"></a-cylinder>
+        <a-cone position="2 1 -3" radius-bottom="0.5" height="1" color="#7BC8A4"></a-cone>
+        <a-torus-knot position="0 2 -4" radius="0.5" radius-tubular="0.1" color="#F0F"></a-torus-knot>
         <a-plane position="0 0 -4" rotation="-90 0 0" width="4" height="4" color="#7BC8A4"></a-plane>
         <a-sky color="#ECECEC"></a-sky>
       </a-scene>
@@ -43,7 +67,7 @@
     let offsetY = 0;
 
     function setup() {
-      const c = createCanvas(windowWidth, windowHeight / 2);
+      const c = createCanvas(800, 800);
       c.parent('canvas2d');
     }
 
@@ -107,7 +131,7 @@
     }
 
     function windowResized() {
-      resizeCanvas(windowWidth, windowHeight / 2);
+      resizeCanvas(800, 800);
     }
   </script>
 </body>


### PR DESCRIPTION
## Summary
- customize grid layout using CSS grid
- place the 3D canvas in row 2, column 3 with 300px by 300px
- enlarge the image canvas to 800px by 800px
- add three more 3D shapes to the scene

## Testing
- `git status --short`
