### PR TITLE
Add interactive IMAT blog design

### DIFF
--- a/imat-blog.html
+++ b/imat-blog.html
@@ -1,0 +1,272 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>IMAT 2025: Your Medical Journey Starts Here</title>
+  <style>
+    body {
+      font-family: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;
+      margin: 0;
+      color: #333;
+      line-height: 1.6;
+      background: #fafafa;
+    }
+    header {
+      background: #0d1b2a;
+      color: white;
+      padding: 3rem 1rem;
+      text-align: center;
+    }
+    header h1 {
+      margin: 0;
+      font-size: 3rem;
+      background: linear-gradient(90deg, #5de0e6, #004aad);
+      -webkit-background-clip: text;
+      color: transparent;
+    }
+    .container {
+      max-width: 900px;
+      margin: 0 auto;
+      padding: 2rem 1rem;
+    }
+    .tldr {
+      background: #fff;
+      border-left: 4px solid #004aad;
+      padding: 1rem;
+      margin-bottom: 2rem;
+    }
+    details {
+      border: 1px solid #ddd;
+      border-radius: 4px;
+      margin-bottom: 1rem;
+      background: #fff;
+    }
+    summary {
+      padding: 1rem;
+      cursor: pointer;
+      font-weight: bold;
+      position: relative;
+    }
+    summary::-webkit-details-marker {
+      display: none;
+    }
+    summary:after {
+      content: '\25BC';
+      position: absolute;
+      right: 1rem;
+      transition: transform 0.3s ease;
+    }
+    details[open] summary:after {
+      transform: rotate(180deg);
+    }
+    details > *:not(summary) {
+      padding: 0 1rem 1rem 1rem;
+    }
+    table {
+      width: 100%;
+      border-collapse: collapse;
+      margin: 1rem 0;
+    }
+    th, td {
+      padding: 0.5rem;
+      border: 1px solid #ccc;
+    }
+    tr:hover {
+      background: #f0f8ff;
+    }
+    .tabs {
+      display: flex;
+      border-bottom: 2px solid #004aad;
+      margin-bottom: 1rem;
+    }
+    .tabs button {
+      flex: 1;
+      padding: 0.5rem;
+      background: #eee;
+      border: none;
+      cursor: pointer;
+      font-weight: bold;
+    }
+    .tabs button.active {
+      background: #004aad;
+      color: #fff;
+    }
+    [role="tabpanel"] {
+      display: none;
+    }
+    [role="tabpanel"].active {
+      display: block;
+    }
+    footer {
+      text-align: center;
+      padding: 1rem;
+      background: #f4f4f4;
+      font-size: 0.9rem;
+    }
+  </style>
+</head>
+<body>
+  <header>
+    <h1>IMAT 2025: Your Medical Journey Starts Here</h1>
+    <p>Thinking about studying medicine in Italy in English? Whether you're dreaming of white coats or just feeling overwhelmed by the competition, this is where your journey begins. At MedexPhage, we've helped hundreds of students get into top Italian med schools. Now it's your turn.</p>
+    <p>In this ultimate guide to IMAT 2025, you'll find the exact dates, official updates, insider tips, and strategy breakdowns that future doctors are searching for. Don't skim and guess. Scroll and conquer.</p>
+  </header>
+
+  <div class="container">
+    <section class="tldr">
+      <h2>TL;DR for the Frantic Scroller</h2>
+      <ul>
+        <li>Exam date: Wednesday 17 September 2025, same global start-time system as always.</li>
+        <li>Registration window opens mid-summer with a 2-3 week deadline set in the MUR decree.</li>
+        <li>No format shake-up: 60 Q / 100 min / paper-based (4 GK, 5 Logic, 23 Bio, 15 Chem, 13 Phys+Math).</li>
+        <li>Universities: 16 public med schools + 2 dentistry programmes (Cagliari newest).</li>
+        <li>Pre-enrolment for non-EU closes 31 July 2025 (upload diploma + DoV/CIMEA).</li>
+        <li>Toughest 2024 cut-offs: Bologna 74.5 (non-EU) &amp; Milan Statale 69.2 (EU); easiest Cagliari 56.5/56.9.</li>
+        <li>Italian open-semester reform excludes English courses, so IMAT stays for 2025.</li>
+      </ul>
+    </section>
+
+    <details open>
+      <summary>1 | Key 2025 Timeline 📅</summary>
+      <table>
+        <tr><th>Phase</th><th>Date*</th><th>What to do</th></tr>
+        <tr><td>MUR decree &amp; seat numbers</td><td>July 2025 (expected)</td><td>Download official call, note your seat quotas</td></tr>
+        <tr><td>Universitaly IMAT registration opens</td><td>mid-July 2025</td><td>Create/refresh account, rank uni preferences, pick test centre</td></tr>
+        <tr><td>Registration closes</td><td>early-Aug 2025</td><td>Pay &euro;130 fee before portal locks</td></tr>
+        <tr><td>Non-EU pre-enrolment deadline</td><td>31 July 2025</td><td>Upload diploma + DoV/CIMEA, wait for uni approval, book embassy slot</td></tr>
+        <tr><td>Exam day</td><td>Wed 17 Sept 2025 11:00 CET</td><td>Arrive with passport/ID</td></tr>
+        <tr><td>Answer key released</td><td>same or next day</td><td>Self-score &amp; de-stress</td></tr>
+        <tr><td>Anonymous score list</td><td>~1 wk later</td><td>Check candidate code</td></tr>
+        <tr><td>EU ranked list / non-EU rankings</td><td>2-3 wks post-exam</td><td>See if you cleared the cut-off</td></tr>
+        <tr><td>In-person enrollment</td><td>Oct–Nov 2025</td><td>Bring originals, pay tuition, start life in Italy!</td></tr>
+      </table>
+      <p>*Precise dates will be in the 2025 decree; set a reminder the moment it drops.</p>
+    </details>
+
+    <details>
+      <summary>2 | What's Really New for IMAT 2025? 🆕</summary>
+      <table>
+        <tr><th>Update</th><th>Reality check</th></tr>
+        <tr><td>"IMAT goes online."</td><td>Nope. Still paper, single sitting worldwide.</td></tr>
+        <tr><td>Cambridge dropped out.</td><td>True—since 2023 MUR writes the exam and tweaked question balance.</td></tr>
+        <tr><td>Italian reform kills the test.</td><td>Only for Italian-language degrees. English courses keep IMAT.</td></tr>
+        <tr><td>More seats?</td><td>Yes—MUR keeps adding places. Watch the July decree for totals.</td></tr>
+      </table>
+    </details>
+
+    <details>
+      <summary>3 | Exam Structure &amp; Syllabus 📚</summary>
+      <table>
+        <tr><th>Section</th><th>Qs</th><th>Tips</th></tr>
+        <tr><td>Reading &amp; General Knowledge</td><td>4</td><td>Skim Italian &amp; international headlines, basic arts &amp; history</td></tr>
+        <tr><td>Logical Reasoning</td><td>5</td><td>Practice Cambridge-style multi-statement puzzles</td></tr>
+        <tr><td>Biology</td><td>23</td><td>Focus on genetics, cell signalling, immunity</td></tr>
+        <tr><td>Chemistry</td><td>15</td><td>Stoichiometry &amp; organic basics dominate</td></tr>
+        <tr><td>Physics + Math</td><td>13</td><td>Graphs, kinematics, algebra, basic circuits</td></tr>
+      </table>
+      <p>Scoring = +1.5 / –0.4 / 0 (max 90). Tie-break: Logic &gt; Bio &gt; Chem &gt; Phys/Math.</p>
+      <p>Download our free topic-by-topic PDF checklist at the end of this post.</p>
+    </details>
+
+    <details>
+      <summary>4 | All Universities Using IMAT in 2025 🏛️</summary>
+      <table>
+        <tr><th>#</th><th>University</th><th>City</th><th>Seats (EU / non-EU 2024)</th><th>2024 Cut-off*</th></tr>
+        <tr><td>1</td><td>Pavia</td><td>Pavia</td><td>103 / 40</td><td>EU 61.8 | non-EU 71.5</td></tr>
+        <tr><td>2</td><td>Milan – Statale</td><td>Milan</td><td>55 / 15</td><td>EU 69.2 | non-EU 75.3</td></tr>
+        <tr><td>3</td><td>Milan – Bicocca</td><td>Milan</td><td>30 / 18</td><td>EU 66.7 | non-EU 72.7</td></tr>
+        <tr><td>4</td><td>Bologna</td><td>Bologna</td><td>97 / 20</td><td>EU 65.6 | non-EU 74.5</td></tr>
+        <tr><td>5</td><td>Padua</td><td>Padua</td><td>75 / 25</td><td>EU 64.6 | non-EU 71.6</td></tr>
+        <tr><td>6</td><td>Turin</td><td>Turin</td><td>70 / 31</td><td>EU 62.4 | non-EU 70.8</td></tr>
+        <tr><td>7</td><td>Rome – Sapienza</td><td>Rome</td><td>45 / 13</td><td>EU 65.5 | non-EU 73.8</td></tr>
+        <tr><td>8</td><td>Rome – Tor Vergata</td><td>Rome</td><td>40 / 15</td><td>EU 62.0 | non-EU 60.6</td></tr>
+        <tr><td>9</td><td>Naples – Federico II</td><td>Naples</td><td>15 / 25</td><td>EU 64.0 | non-EU 68.1</td></tr>
+        <tr><td>10</td><td>Campania – Vanvitelli</td><td>Naples</td><td>60 / 50</td><td>EU 59.5 | non-EU 63.2</td></tr>
+        <tr><td>11</td><td>Bari</td><td>Bari</td><td>69 / 11</td><td>EU 59.1 | non-EU 65.8</td></tr>
+        <tr><td>12</td><td>Parma</td><td>Parma</td><td>75 / 45</td><td>EU 60.3 | non-EU 59.1</td></tr>
+        <tr><td>13</td><td>Messina</td><td>Messina</td><td>55 / 56</td><td>EU 57.6 | non-EU 61.8</td></tr>
+        <tr><td>14</td><td>Marche (Ancona)</td><td>Ancona</td><td>20 / 60</td><td>EU 60.2 | non-EU 60.3</td></tr>
+        <tr><td>15</td><td>Cagliari</td><td>Cagliari</td><td>80 / 20</td><td>EU 56.9 | non-EU 56.5</td></tr>
+        <tr><td>16</td><td>Catania</td><td>Catania</td><td>30 / 30</td><td>EU 58.4 | non-EU 57.2</td></tr>
+        <tr><td>17</td><td>Dentistry – Rome Sapienza</td><td>Rome</td><td>42 / 6</td><td>EU 59.7 | non-EU 73.1</td></tr>
+        <tr><td>18</td><td>Dentistry – Siena</td><td>Siena</td><td>23 / 12</td><td>EU 59.7 | non-EU 69.3</td></tr>
+      </table>
+      <p>*First-round 2024 figures. Source: Universitaly rankings &amp; live cut-off trackers.</p>
+      <p>Take-away: If you need a safety option, Cagliari, Messina or Parma offered the lowest EU thresholds in 2024. Dreaming of Milan or Bologna? Aim 70+.</p>
+    </details>
+
+    <details>
+      <summary>5 | Test-Centre Locations 🌍</summary>
+      <p><strong>Italy:</strong> You'll sit the test at your first-choice university's campus—Milan, Rome, Padua, etc.</p>
+      <p><strong>Abroad:</strong> IMAT 2024 ran in 24 countries including London, Dublin, Paris, Berlin, New York, Toronto, Dubai, Delhi and Johannesburg. Expect a near-identical 2025 list.</p>
+      <p>Tip: Popular hubs fill fast—book the moment the external link appears after you pay on Universitaly.</p>
+    </details>
+
+    <details>
+      <summary>6 | Registration Walk-Through 🔑</summary>
+      <div class="tabs" role="tablist">
+        <button role="tab" aria-controls="eu" class="active">EU / EU-Equivalent</button>
+        <button role="tab" aria-controls="noneu">Non-EU</button>
+      </div>
+      <div id="eu" role="tabpanel" class="active">
+        <ol>
+          <li>Create Universitaly account (free).</li>
+          <li>Complete IMAT form during the 2025 window.</li>
+          <li>Rank any number of universities; order matters for seat allocation.</li>
+          <li>Declare English certificate if you have one.</li>
+          <li>Pay &euro;130 fee and keep confirmation email.</li>
+          <li>Print receipt and bring ID on exam day.</li>
+        </ol>
+      </div>
+      <div id="noneu" role="tabpanel">
+        <ol>
+          <li>Pre-enrol on Universitaly before 31 July 2025 (upload passport, diploma, DoV or CIMEA).</li>
+          <li>Wait for university approval then book your embassy visa slot.</li>
+          <li>Register for IMAT in July/Aug; only your first-choice university counts.</li>
+          <li>Choose overseas test centre &amp; pay the fee.</li>
+          <li>Sit the exam, then complete visa steps and fly to Italy if admitted.</li>
+        </ol>
+        <p class="note">CIMEA portals close mid-Aug; start document verification early.</p>
+      </div>
+    </details>
+
+    <details>
+      <summary>7 | 2024 Cut-Off Heat-Map 🔥</summary>
+      <table>
+        <tr><th>70+</th><th>65–69</th><th>60–64</th><th>&lt; 60</th></tr>
+        <tr><td>Bologna (N-EU 74.5)</td><td></td><td></td><td></td></tr>
+        <tr><td>Milan Statale (EU 69.2)</td><td>Padua 64.6</td><td>Bologna EU 65.6</td><td>Turin 62.4</td></tr>
+        <tr><td>Vanvitelli 63.2</td><td>Tor Vergata 62.0</td><td>Cagliari 56.5 / 56.9</td><td>Messina 57.6</td></tr>
+      </table>
+    </details>
+
+    <footer>
+      &copy; 2025 MedexPhage. All rights reserved.
+    </footer>
+  </div>
+
+  <script>
+    document.querySelectorAll('details').forEach(d => {
+      d.addEventListener('toggle', () => {
+        if (d.open) {
+          document.querySelectorAll('details').forEach(other => {
+            if (other !== d) other.removeAttribute('open');
+          });
+        }
+      });
+    });
+
+    const tabs = document.querySelectorAll('[role="tab"]');
+    tabs.forEach(tab => {
+      tab.addEventListener('click', () => {
+        const target = document.getElementById(tab.getAttribute('aria-controls'));
+        document.querySelectorAll('[role="tabpanel"]').forEach(p => p.classList.remove('active'));
+        document.querySelectorAll('[role="tab"]').forEach(t => t.classList.remove('active'));
+        target.classList.add('active');
+        tab.classList.add('active');
+      });
+    });
+  </script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- revamp `imat-blog.html` with a magazine-style layout
- add accordion sections and tabs for registration walkthrough
- include TL;DR, updated timelines and 2024 cutoff heat map
- close-open script ensures only one accordion is expanded

## Testing
- `git status --short`